### PR TITLE
Cleanup logger initialization

### DIFF
--- a/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/DriverStationBackend.java
+++ b/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/DriverStationBackend.java
@@ -2,7 +2,7 @@ package org.inspirerobotics.sumobots.driverstation;
 
 import org.inspirerobotics.sumobots.driverstation.field.Field;
 import org.inspirerobotics.sumobots.driverstation.robot.Robot;
-import org.inspirerobotics.sumobots.library.Resources;
+import org.inspirerobotics.sumobots.library.InternalLog;
 import org.inspirerobotics.sumobots.library.TimePeriod;
 import org.inspirerobotics.sumobots.library.concurrent.InterThreadMessage;
 import org.inspirerobotics.sumobots.library.concurrent.ThreadChannel;
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 
 public class DriverStationBackend extends Thread {
 
-	private final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private final Logger logger = InternalLog.getLogger();
 
 	private final Field field = new Field(this);
 

--- a/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/field/Field.java
+++ b/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/field/Field.java
@@ -3,6 +3,7 @@ package org.inspirerobotics.sumobots.driverstation.field;
 import org.inspirerobotics.sumobots.driverstation.DriverStationBackend;
 import org.inspirerobotics.sumobots.driverstation.Settings;
 import org.inspirerobotics.sumobots.driverstation.util.EmptyConnection;
+import org.inspirerobotics.sumobots.library.InternalLog;
 import org.inspirerobotics.sumobots.library.Resources;
 import org.inspirerobotics.sumobots.library.TimePeriod;
 import org.inspirerobotics.sumobots.library.concurrent.InterThreadMessage;
@@ -19,7 +20,7 @@ import java.util.logging.Logger;
 
 public class Field implements ConnectionListener {
 
-	private final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private final Logger logger = InternalLog.getLogger();
 
 	private Connection fieldConnection;
 	private TimePeriod currentPeriod;

--- a/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/gui/MainScene.java
+++ b/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/gui/MainScene.java
@@ -2,17 +2,19 @@ package org.inspirerobotics.sumobots.driverstation.gui;
 
 import javafx.scene.Scene;
 import javafx.scene.layout.AnchorPane;
-import org.inspirerobotics.sumobots.library.Resources;
+import org.inspirerobotics.sumobots.library.InternalLog;
 import org.inspirerobotics.sumobots.library.gui.FXMLFileLoader;
 
 import java.util.logging.Logger;
 
 public class MainScene extends AnchorPane {
 
-	private Logger log = Logger.getLogger(Resources.LOGGER_NAME);
+	private Logger log = InternalLog.getLogger();
 
 	public MainScene(GuiController controller) {
 		FXMLFileLoader.load("root.fxml", controller, this);
+
+		log.info("Main Scene initialized");
 	}
 
 	public Scene toScene() {

--- a/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/robot/Robot.java
+++ b/sumobots/driverstation/src/main/java/org/inspirerobotics/sumobots/driverstation/robot/Robot.java
@@ -1,6 +1,7 @@
 package org.inspirerobotics.sumobots.driverstation.robot;
 
 import org.inspirerobotics.sumobots.driverstation.DriverStationBackend;
+import org.inspirerobotics.sumobots.library.InternalLog;
 import org.inspirerobotics.sumobots.library.Resources;
 import org.inspirerobotics.sumobots.library.concurrent.InterThreadMessage;
 import org.inspirerobotics.sumobots.library.networking.connection.Connection;
@@ -15,7 +16,7 @@ import java.util.logging.Logger;
 
 public class Robot implements ConnectionListener {
 
-	private final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private final Logger logger = InternalLog.getLogger();
 
 	private Connection robotConnection;
 	private final DriverStationBackend backend;

--- a/sumobots/field/src/main/java/org/inspirerobotics/sumobots/field/gui/gametab/ControlPane.java
+++ b/sumobots/field/src/main/java/org/inspirerobotics/sumobots/field/gui/gametab/ControlPane.java
@@ -7,7 +7,6 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import org.inspirerobotics.sumobots.field.FieldFrontend;
 import org.inspirerobotics.sumobots.library.InternalLog;
-import org.inspirerobotics.sumobots.library.Resources;
 import org.inspirerobotics.sumobots.library.gui.FXMLFileLoader;
 
 import java.util.List;
@@ -15,7 +14,7 @@ import java.util.logging.Logger;
 
 public class ControlPane extends AnchorPane {
 
-	private static final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private static final Logger logger = InternalLog.getLogger();
 
 	private final FieldFrontend fieldFrontend;
 

--- a/sumobots/field/src/main/java/org/inspirerobotics/sumobots/field/util/AudioEffect.java
+++ b/sumobots/field/src/main/java/org/inspirerobotics/sumobots/field/util/AudioEffect.java
@@ -1,6 +1,6 @@
 package org.inspirerobotics.sumobots.field.util;
 
-import org.inspirerobotics.sumobots.library.Resources;
+import org.inspirerobotics.sumobots.library.InternalLog;
 import sun.audio.AudioPlayer;
 import sun.audio.AudioStream;
 
@@ -11,20 +11,21 @@ import java.util.logging.Logger;
 
 public class AudioEffect {
 
+	private static final Logger logger = InternalLog.getLogger();
+
 	public static void play(String filename) {
 		try {
-			Logger.getLogger(Resources.LOGGER_NAME).fine("Playing Sound: " + filename);
+			logger.fine("Playing Sound: " + filename);
 
 			AudioPlayer.player.start(createAudioStream(filename));
 		} catch (IOException e) {
 			e.printStackTrace();
-			Logger.getLogger(Resources.LOGGER_NAME)
-					.severe(String.format("IO Error \"%s\" while loading sound file: " + filename, e.getMessage()));
+			logger.severe(String.format("IO Error \"%s\" while loading sound file: " + filename, e.getMessage()));
 		}
 	}
 
 	public static AudioStream createAudioStream(String name) throws IOException {
-		Logger.getLogger(Resources.LOGGER_NAME).info("Loading file: sounds/" + name);
+		logger.info("Loading file: sounds/" + name);
 
 		InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("sounds/" + name);
 

--- a/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/Resources.java
+++ b/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/Resources.java
@@ -4,7 +4,7 @@ public class Resources {
 
 	public static final String LIBRARY_VERSION = "0.2.1";
 
-	public static final String LOGGER_NAME = "com.inspirerobotics.sumobots";
+	static final String LOGGER_NAME = "com.inspirerobotics.sumobots";
 
 	public static final int SERVER_PORT = 4283;
 

--- a/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/concurrent/ThreadChannel.java
+++ b/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/concurrent/ThreadChannel.java
@@ -1,13 +1,13 @@
 package org.inspirerobotics.sumobots.library.concurrent;
 
-import org.inspirerobotics.sumobots.library.Resources;
+import org.inspirerobotics.sumobots.library.InternalLog;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Logger;
 
 public class ThreadChannel {
 
-	private final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private final Logger logger = InternalLog.getLogger();
 
 	private final ConcurrentLinkedQueue<InterThreadMessage> tx;
 

--- a/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/config/Config.java
+++ b/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/config/Config.java
@@ -1,14 +1,14 @@
 package org.inspirerobotics.sumobots.library.config;
 
 import me.grison.jtoml.impl.Toml;
-import org.inspirerobotics.sumobots.library.Resources;
+import org.inspirerobotics.sumobots.library.InternalLog;
 
 import java.io.IOException;
 import java.util.logging.Logger;
 
 public class Config {
 
-	private static final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private static final Logger logger = InternalLog.getLogger();
 
 	private Toml toml;
 	private final String name;

--- a/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/config/ConfigLoader.java
+++ b/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/config/ConfigLoader.java
@@ -1,7 +1,7 @@
 package org.inspirerobotics.sumobots.library.config;
 
 import me.grison.jtoml.impl.Toml;
-import org.inspirerobotics.sumobots.library.Resources;
+import org.inspirerobotics.sumobots.library.InternalLog;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,7 +9,7 @@ import java.util.logging.Logger;
 
 public class ConfigLoader {
 
-	private static final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private static final Logger logger = InternalLog.getLogger();
 
 	public static Toml loadToml(String name) throws IOException {
 		String path = getPath(name);

--- a/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/networking/Server.java
+++ b/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/networking/Server.java
@@ -1,5 +1,6 @@
 package org.inspirerobotics.sumobots.library.networking;
 
+import org.inspirerobotics.sumobots.library.InternalLog;
 import org.inspirerobotics.sumobots.library.Resources;
 import org.inspirerobotics.sumobots.library.networking.connection.Connection;
 import org.inspirerobotics.sumobots.library.networking.connection.ConnectionListener;
@@ -18,7 +19,7 @@ import java.util.logging.Logger;
 
 public class Server {
 
-	private final Logger log = Logger.getLogger(Resources.LOGGER_NAME);
+	private final Logger log = InternalLog.getLogger();
 
 	private final ServerSocket serverSocket;
 

--- a/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/networking/SocketStream.java
+++ b/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/networking/SocketStream.java
@@ -1,5 +1,6 @@
 package org.inspirerobotics.sumobots.library.networking;
 
+import org.inspirerobotics.sumobots.library.InternalLog;
 import org.inspirerobotics.sumobots.library.Resources;
 
 import java.io.*;
@@ -20,7 +21,7 @@ public class SocketStream {
 
 	private boolean closed = false;
 
-	private final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private final Logger logger = InternalLog.getLogger();
 
 	public SocketStream(InputStream reader, OutputStream writer, Socket socket) {
 		super();

--- a/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/networking/connection/Connection.java
+++ b/sumobots/library/src/main/java/org/inspirerobotics/sumobots/library/networking/connection/Connection.java
@@ -1,5 +1,6 @@
 package org.inspirerobotics.sumobots.library.networking.connection;
 
+import org.inspirerobotics.sumobots.library.InternalLog;
 import org.inspirerobotics.sumobots.library.Resources;
 import org.inspirerobotics.sumobots.library.networking.SocketStream;
 import org.inspirerobotics.sumobots.library.networking.message.ArchetypalMessages;
@@ -20,7 +21,7 @@ public class Connection {
 
 	private final ConnectionListener listener;
 
-	private final Logger logger = Logger.getLogger(Resources.LOGGER_NAME);
+	private final Logger logger = InternalLog.getLogger();
 
 	private boolean closed = false;
 


### PR DESCRIPTION
fixes #32 

Before we were using both Logger.getLogger() and InternalLog.getLogger().
Now we are only going to use InternalLog.getLogger() that way the internal
logger is always initialized during tests. This commit also hides the logger
name variable in Resources.java to package level only. This is too prevent people
from referencing this variable in Logger.getLogger(name)